### PR TITLE
API Version Text Bump API: 3.0.0-ALPHA1

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,7 +1,7 @@
 name: DevTools
 main: DevTools\DevTools
 version: 1.11.1
-api: 2.0.0
+api: 3.0.0-ALPHA1
 load: STARTUP
 author: PocketMine Team
 description: Helps develop and distribute PocketMine-MP plugins


### PR DESCRIPTION
I just found that for some reason APIs 3.0.0 and 3.0.0-ALPHA1 are similar.
New Features:
 - Making API 2.0 compatible with 3.0 ALPHA1